### PR TITLE
Optionally add still frames at the end closes #56

### DIFF
--- a/src/main/java/sk/freemap/gpxAnimator/Configuration.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Configuration.java
@@ -49,7 +49,9 @@ public class Configuration {
 	@XmlJavaTypeAdapter(ColorXmlAdapter.class)
 	private Color flashbackColor;
 	private Long flashbackDuration;
-	
+
+	private Long keepLastFrame;
+
 	@XmlJavaTypeAdapter(FileXmlAdapter.class)
 	private File output;
 	private String attribution;
@@ -79,7 +81,7 @@ public class Configuration {
 			final Double speedup, final long tailDuration, final double fps, final Long totalTime,
 			final float backgroundMapVisibility, final String tmsUrlTemplate,
 			final boolean skipIdle, final Color flashbackColor, final Long flashbackDuration,
-			final File output, final String attribution,
+			final Long keepLastFrame, final File output, final String attribution,
 			final int fontSize, final Double markerSize, final Double waypointSize,
 			final Double minLon, final Double maxLon, final Double minLat, final Double maxLat,
 			final List<TrackConfiguration> trackConfigurationList) {
@@ -97,6 +99,7 @@ public class Configuration {
 		this.skipIdle = skipIdle;
 		this.flashbackColor = flashbackColor;
 		this.flashbackDuration = flashbackDuration;
+		this.keepLastFrame = keepLastFrame;
 		this.output = output;
 		this.attribution = attribution;
 		this.fontSize = fontSize;
@@ -148,8 +151,8 @@ public class Configuration {
 	public Long getTotalTime() {
 		return totalTime;
 	}
-	
-	
+
+
 	public float getBackgroundMapVisibility() {
 		return backgroundMapVisibility;
 	}
@@ -172,6 +175,11 @@ public class Configuration {
 	
 	public Long getFlashbackDuration() {
 		return flashbackDuration;
+	}
+	
+	
+	public Long getKeepLastFrame() {
+		return keepLastFrame;
 	}
 	
 	
@@ -246,7 +254,9 @@ public class Configuration {
 		private boolean skipIdle = true;
 		private Color flashbackColor = Color.white;
 		private Long flashbackDuration = 250l;
-		
+
+		private Long keepLastFrame;
+
 		private File output = new File("video.mp4"); // frame%08d.png
 		private String attribution = "Created by GPX Animator " + Constants.VERSION + "\n%MAP_ATTRIBUTION%";
 		
@@ -268,7 +278,7 @@ public class Configuration {
 					speedup, tailDuration, fps, totalTime,
 					backgroundMapVisibility, tmsUrlTemplate,
 					skipIdle, flashbackColor, flashbackDuration,
-					output, attribution,
+					keepLastFrame, output, attribution,
 					fontSize, markerSize, waypointSize,
 					minLon,	maxLon,	minLat,	maxLat,
 
@@ -339,6 +349,11 @@ public class Configuration {
 
 		public Builder flashbackDuration(final Long flashbackDuration) {
 			this.flashbackDuration = flashbackDuration;
+			return this;
+		}
+
+		public Builder keepLastFrame(final Long keepLastFrame) {
+			this.keepLastFrame = keepLastFrame;
 			return this;
 		}
 

--- a/src/main/java/sk/freemap/gpxAnimator/Option.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Option.java
@@ -34,6 +34,7 @@ public enum Option {
 	KEEP_IDLE("keep-idle", "keep parts where no movement is present"),
 	FLASHBACK_COLOR("flashback-color", "transition color between non-idle parts"),
 	FLASHBACK_DURATION("flashback-duration", "color of the idle-skipping flashback effect in #AARRGGBB representation"),
+	KEEP_LAST_FRAME("keep-last-frame", "time to repeat the last rendered frame in milliseconds; complementary to total time"),
 	SKIP_IDLE("skip-idle", "idle-skipping flashback effect duration in milliseconds; set to empty for no flashback"),
 	HELP("help", "this help");
 	

--- a/src/main/java/sk/freemap/gpxAnimator/Renderer.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Renderer.java
@@ -215,6 +215,8 @@ public class Renderer {
 
 		final int frames = (int) ((maxTime + cfg.getTailDuration() - minTime) * cfg.getFps() / (MS * speedup));
 
+		final boolean keepLastFrame = cfg.getKeepLastFrame() != null && cfg.getKeepLastFrame().longValue() > 0;
+
 		float skip = -1f;
 		for (int frame = 1; frame < frames; frame++) {
 			if (rc.isCancelled1()) {
@@ -259,6 +261,18 @@ public class Renderer {
 			}
 
 			frameWriter.addFrame(bi2);
+
+			if (keepLastFrame && frame == frames - 1) { // last frame
+				final long ms = cfg.getKeepLastFrame().longValue();
+				final long fps = Double.valueOf(cfg.getFps()).longValue();
+				final long stillFrames = ms / 1_000 * fps;
+				for (long stillFrame = 0; stillFrame < stillFrames; stillFrame++) {
+					frameWriter.addFrame(bi2);
+					if (rc.isCancelled1()) {
+						return;
+					}
+				}
+			}
 		}
 
 		frameWriter.close();

--- a/src/main/java/sk/freemap/gpxAnimator/ui/GeneralSettingsPanel.java
+++ b/src/main/java/sk/freemap/gpxAnimator/ui/GeneralSettingsPanel.java
@@ -61,6 +61,7 @@ abstract class GeneralSettingsPanel extends JPanel {
 	private final JCheckBox skipIdleCheckBox;
 	private final ColorSelector flashbackColorSelector;
 	private final JSpinner flashbackDurationSpinner;
+	private final JSpinner keepLastFrameSpinner;
 	private final JSpinner totalTimeSpinner;
 	private JTextArea attributionTextArea;
 
@@ -90,9 +91,9 @@ abstract class GeneralSettingsPanel extends JPanel {
 		setBorder(new EmptyBorder(5, 5, 5, 5));
 		final GridBagLayout gridBagLayout = new GridBagLayout();
 		gridBagLayout.columnWidths = new int[]{91, 100, 0, 0};
-		gridBagLayout.rowHeights = new int[]{14, 20, 20, 20, 14, 20, 20, 20, 20, 20, 20, 20, 20, 50, 45, 20, 21, 23, 20, 0};
+		gridBagLayout.rowHeights = new int[]{14, 20, 20, 20, 14, 20, 20, 20, 20, 20, 20, 20, 20, 50, 45, 20, 21, 23, 20, 20, 0};
 		gridBagLayout.columnWeights = new double[]{0.0, 1.0, 0.0, Double.MIN_VALUE};
-		gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE};
+		gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE};
 		setLayout(gridBagLayout);
 
 						final JLabel lblOutput = new JLabel("Output");
@@ -607,6 +608,25 @@ abstract class GeneralSettingsPanel extends JPanel {
 		gbc_flashbackDurationSpinner.gridy = 18;
 		add(flashbackDurationSpinner, gbc_flashbackDurationSpinner);
 		flashbackDurationSpinner.addChangeListener(changeListener);
+
+		final JLabel lblKeepLastFrame = new JLabel("Keep Last Frame");
+		final GridBagConstraints gbc_lblKeepLastFrame = new GridBagConstraints();
+		gbc_lblKeepLastFrame.anchor = GridBagConstraints.EAST;
+		gbc_lblKeepLastFrame.insets = new Insets(0, 0, 0, 5);
+		gbc_lblKeepLastFrame.gridx = 0;
+		gbc_lblKeepLastFrame.gridy = 19;
+		add(lblKeepLastFrame, gbc_lblKeepLastFrame);
+
+		keepLastFrameSpinner = new JSpinner();
+		keepLastFrameSpinner.setToolTipText(Option.KEEP_LAST_FRAME.getHelp());
+		keepLastFrameSpinner.setModel(new DurationSpinnerModel());
+		keepLastFrameSpinner.setEditor(new DurationEditor(keepLastFrameSpinner));
+		final GridBagConstraints gbc_keepLastFrameSpinner = new GridBagConstraints();
+		gbc_keepLastFrameSpinner.fill = GridBagConstraints.HORIZONTAL;
+		gbc_keepLastFrameSpinner.gridx = 1;
+		gbc_keepLastFrameSpinner.gridy = 19;
+		add(keepLastFrameSpinner, gbc_keepLastFrameSpinner);
+		keepLastFrameSpinner.addChangeListener(changeListener);
 	}
 
 	private List<MapTemplate> readMaps() {
@@ -723,6 +743,7 @@ abstract class GeneralSettingsPanel extends JPanel {
 		b.tailDuration(td == null ? 0l : td.longValue());
 		b.fps((Double) fpsSpinner.getValue());
 		b.totalTime((Long) totalTimeSpinner.getValue());
+		b.keepLastFrame((Long) keepLastFrameSpinner.getValue());
 		b.backgroundMapVisibility(backgroundMapVisibilitySlider.getValue() / 100f);
 		final Object tmsItem = tmsUrlTemplateComboBox.getSelectedItem();
 		final String tmsUrlTemplate = tmsItem instanceof MapTemplate ? ((MapTemplate) tmsItem).getUrl() : (String) tmsItem;


### PR DESCRIPTION
I added a new configuration option to specify a duration the last rendered frame will be repeated until the video file ends. That was a request originally from a youtuber who uses GPX Animator for his bicycle trip reports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zdila/gpx-animator/57)
<!-- Reviewable:end -->
