### PR TITLE
Adding photos to the animation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,5 +89,15 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.25</version>
 		</dependency>
+		<dependency>
+			<groupId>com.drewnoakes</groupId>
+			<artifactId>metadata-extractor</artifactId>
+			<version>2.11.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.imgscalr</groupId>
+			<artifactId>imgscalr-lib</artifactId>
+			<version>4.2</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/sk/freemap/gpxAnimator/Configuration.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Configuration.java
@@ -14,18 +14,13 @@
  */
 package sk.freemap.gpxAnimator;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.awt.Color;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -65,6 +60,9 @@ public class Configuration {
 	private Double minLat;
 	private Double maxLat;
 
+	private File photos;
+	private Long photoTime;
+
 	@XmlElementWrapper
 	@XmlElement(name = "trackConfiguration")
 	private List<TrackConfiguration> trackConfigurationList;
@@ -84,6 +82,7 @@ public class Configuration {
 			final Long keepLastFrame, final File output, final String attribution,
 			final int fontSize, final Double markerSize, final Double waypointSize,
 			final Double minLon, final Double maxLon, final Double minLat, final Double maxLat,
+			final File photos, final Long photoTime,
 			final List<TrackConfiguration> trackConfigurationList) {
 		
 		this.margin = margin;
@@ -110,6 +109,8 @@ public class Configuration {
 		this.maxLon = maxLon;
 		this.minLat = minLat;
 		this.maxLat = maxLat;
+		this.photos = photos;
+		this.photoTime = photoTime;
 	}
 
 
@@ -226,7 +227,17 @@ public class Configuration {
 		return maxLat;
 	}
 
-	
+
+	public File getPhotos() {
+		return photos;
+	}
+
+
+	public Long getPhotoTime() {
+		return photoTime;
+	}
+
+
 	public List<TrackConfiguration> getTrackConfigurationList() {
 		return trackConfigurationList;
 	}
@@ -236,7 +247,7 @@ public class Configuration {
 		return new Builder();
 	}
 
-	
+
 	public static class Builder {
 		private int margin = 20;
 		private Integer height;
@@ -269,6 +280,9 @@ public class Configuration {
 		private Double minLat;
 		private Double maxLat;
 
+		private File photos;
+		private Long photoTime = 3_000L;
+
 		private final List<TrackConfiguration> trackConfigurationList = new ArrayList<TrackConfiguration>();
 		
 
@@ -281,6 +295,7 @@ public class Configuration {
 					keepLastFrame, output, attribution,
 					fontSize, markerSize, waypointSize,
 					minLon,	maxLon,	minLat,	maxLat,
+					photos, photoTime,
 
 					Collections.unmodifiableList(trackConfigurationList)
 			);
@@ -402,6 +417,16 @@ public class Configuration {
 			return this;
 		}
 
+		public Builder photos(final File photos) {
+			this.photos = photos;
+			return this;
+		}
+
+		public Builder photoTime(final Long photoTime) {
+			this.photoTime = photoTime;
+			return this;
+		}
+
 		public Builder addTrackConfiguration(final TrackConfiguration trackConfiguration) {
 			this.trackConfigurationList.add(trackConfiguration);
 			return this;
@@ -427,6 +452,8 @@ public class Configuration {
 				+ ", fontSize=" + fontSize
 				+ ", markerSize=" + markerSize
 				+ ", waypointSize=" + waypointSize
+				+ ", photos=" + photos
+				+ ", photoTime=" + photoTime
 				+ ", trackConfigurationList=" + trackConfigurationList
 				+ "]";
 	}

--- a/src/main/java/sk/freemap/gpxAnimator/Option.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Option.java
@@ -36,6 +36,8 @@ public enum Option {
 	FLASHBACK_DURATION("flashback-duration", "color of the idle-skipping flashback effect in #AARRGGBB representation"),
 	KEEP_LAST_FRAME("keep-last-frame", "time to repeat the last rendered frame in milliseconds; complementary to total time"),
 	SKIP_IDLE("skip-idle", "idle-skipping flashback effect duration in milliseconds; set to empty for no flashback"),
+	PHOTOS("photos", "a directory containing photos to be added to the animation (must contain EXIF information with date and time of photo taken)"),
+	PHOTO_TIME("photo-time", "the amount of time, a photo should be shown above the map"),
 	HELP("help", "this help");
 	
 	private static java.util.Map<String, Option> map = new HashMap<String, Option>();

--- a/src/main/java/sk/freemap/gpxAnimator/Photo.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Photo.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2019 Marcus Fihlon, Switzerland
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package sk.freemap.gpxAnimator;
+
+import com.drew.lang.annotations.NotNull;
+
+import java.io.File;
+import java.util.Objects;
+
+public class Photo {
+    private Long epochSeconds;
+    private File file;
+
+    public Photo(@NotNull Long epochSeconds, @NotNull File file) {
+        this.epochSeconds = epochSeconds;
+        this.file = file;
+    }
+
+    public Long getEpochSeconds() {
+        return epochSeconds;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Photo photo = (Photo) o;
+        return epochSeconds.equals(photo.epochSeconds)  &&
+                file.equals(photo.file);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(epochSeconds, file);
+    }
+
+    @Override
+    public String toString() {
+        return "Photo{" +
+                "epochSeconds=" + epochSeconds +
+                ", file=" + file +
+                '}';
+    }
+}

--- a/src/main/java/sk/freemap/gpxAnimator/Photos.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Photos.java
@@ -1,0 +1,177 @@
+/*
+ *  Copyright 2019 Marcus Fihlon, Switzerland
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package sk.freemap.gpxAnimator;
+
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.ImageProcessingException;
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.ExifSubIFDDirectory;
+import org.imgscalr.Scalr;
+import sk.freemap.gpxAnimator.frameWriter.FrameWriter;
+
+import javax.imageio.ImageIO;
+import javax.imageio.stream.ImageInputStream;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.groupingBy;
+
+public class Photos {
+
+    private final Map<Long, List<Photo>> photos;
+
+    public Photos(@NotNull final File directory) {
+        if (directory.isDirectory()) {
+            final File[] files = directory.listFiles((dir, name) -> {
+                final String lowerCaseName = name.toLowerCase();
+                return lowerCaseName.endsWith(".jpg") || lowerCaseName.endsWith(".jpeg") || lowerCaseName.endsWith(".png");
+            });
+            if (files != null) {
+                photos = Arrays.stream(files).map(Photos::toPhoto).filter(photo -> photo.getEpochSeconds() > 0)
+                        .collect(groupingBy(Photo::getEpochSeconds));
+            } else {
+                photos = new HashMap<>();
+            }
+        } else {
+            System.err.println(String.format("'%s' is not a directory!", directory));
+            photos = new HashMap<>();
+        }
+    }
+
+    private static Photo toPhoto(final File file) {
+        return new Photo(timeOfPhotoInMilliSeconds(file), file);
+    }
+
+    private static Long timeOfPhotoInMilliSeconds(final File file) {
+        try {
+            final Metadata metadata = ImageMetadataReader.readMetadata(file);
+            final ExifSubIFDDirectory directory = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
+            final String dateTimeString = directory.getString(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)
+                    + " " + directory.getString(36881).replace(":", "");
+            final ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateTimeString,
+                    DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss x"));
+            return zonedDateTime.toEpochSecond() * 1_000;
+        } catch (ImageProcessingException | IOException e) {
+            System.err.println(String.format("Error processing file '%s': %s",
+                    file.getAbsolutePath(), e.getMessage()));
+            return 0L;
+        }
+    }
+
+    public void render(final Long gpsTime, final Configuration cfg, final BufferedImage bi,
+                       final FrameWriter frameWriter, final RenderingContext rc, final int pct) {
+        System.out.println("GPS time: " + gpsTime);
+        final List<Long> keys = photos.keySet().stream()
+                .filter(photoTime -> gpsTime >= photoTime)
+                .collect(Collectors.toList());
+        if (!keys.isEmpty()) {
+            keys.stream()
+                    .map(photos::get)
+                    .flatMap(List::stream).collect(Collectors.toList())
+                    .forEach(photo -> Photos.renderPhoto(photo, cfg, bi, frameWriter, rc, pct));
+            keys.forEach(photos::remove);
+        }
+    }
+
+    private static void renderPhoto(final Photo photo, final Configuration cfg,
+                                    final BufferedImage bi, final FrameWriter frameWriter,
+                                    final RenderingContext rc, final int pct) {
+        rc.setProgress1(pct, String.format("Rendering photo '%s'", photo.getFile().getName()));
+
+        final BufferedImage image = readPhoto(photo, bi.getWidth(), bi.getHeight());
+        if (image != null) {
+            final BufferedImage bi2 = Utils.deepCopy(bi);
+            final Graphics2D g2d = bi2.createGraphics();
+            final int posX = (bi.getWidth() - image.getWidth()) / 2;
+            final int posY = (bi.getHeight() - image.getHeight()) / 2;
+            g2d.drawImage(image, posX, posY, null);
+            g2d.dispose();
+
+            final long ms = cfg.getPhotoTime().longValue();
+            final long fps = Double.valueOf(cfg.getFps()).longValue();
+            final long frames = ms * fps / 1_000;
+
+            try {
+                for (long frame = 0; frame < frames; frame++) {
+                    frameWriter.addFrame(bi2);
+                }
+            } catch (final UserException e) {
+                System.err.println(String.format("Problem rendering photo '%s': %s", photo, e.getMessage() ));
+            }
+        }
+    }
+
+    private static BufferedImage readPhoto(final Photo photo, final int width, final int height) {
+        try {
+            final byte[] rawData = getRawBytesFromFile(photo.getFile());
+            final ImageInputStream input = ImageIO.createImageInputStream(new ByteArrayInputStream(rawData));
+            final BufferedImage image = ImageIO.read(input);
+            final int scaledWidth = Math.round(width * 0.7f);
+            final int scaledHeight = Math.round(height * 0.7f);
+            final BufferedImage scaledImage = scaleImage(image, scaledWidth, scaledHeight);
+            return addBorder(scaledImage);
+        } catch (final IOException e) {
+            System.err.println(String.format("Problem reading photo '%s': %s", photo, e.getMessage() ));
+        }
+        return null;
+    }
+
+    private static BufferedImage addBorder(final BufferedImage image) {
+        int borderWidth = Math.round(image.getWidth() / 15);
+        int borderHeight = Math.round(image.getHeight() / 15);
+        int borderSize = borderWidth < borderHeight ? borderWidth : borderHeight;
+        int outerBorderSize = Math.round(borderSize / 5);
+        final BufferedImage border = new BufferedImage(
+                image.getWidth() + 2 * borderSize,
+                image.getHeight() + 2 * borderSize,
+                image.getType());
+
+        final Graphics2D g2d = border.createGraphics();
+        g2d.setColor(Color.DARK_GRAY);
+        g2d.fillRect(0, 0, border.getWidth(), border.getHeight());
+        g2d.setColor(Color.WHITE);
+        g2d.fillRect(outerBorderSize, outerBorderSize,
+                border.getWidth() - (2 * outerBorderSize), border.getHeight() - (2 * outerBorderSize));
+        g2d.drawImage(image, borderSize, borderSize, null);
+        g2d.dispose();
+
+        return border;
+    }
+
+    private static BufferedImage scaleImage(final BufferedImage image, final int width, final int height) {
+        return Scalr.resize(Scalr.resize(image,
+                Scalr.Method.ULTRA_QUALITY, Scalr.Mode.FIT_TO_WIDTH, width),
+                Scalr.Method.ULTRA_QUALITY, Scalr.Mode.FIT_TO_HEIGHT, height);
+    }
+
+    private static byte[] getRawBytesFromFile(final File file) throws IOException {
+        final byte[] image = new byte[(int)file.length()];
+        try (final FileInputStream fileInputStream = new FileInputStream(file)) {
+            //noinspection ResultOfMethodCallIgnored
+            fileInputStream.read(image);
+        }
+        return image;
+    }
+}

--- a/src/main/java/sk/freemap/gpxAnimator/Renderer.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Renderer.java
@@ -14,13 +14,11 @@
  */
 package sk.freemap.gpxAnimator;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.awt.Shape;
+import sk.freemap.gpxAnimator.frameWriter.FileFrameWriter;
+import sk.freemap.gpxAnimator.frameWriter.FrameWriter;
+import sk.freemap.gpxAnimator.frameWriter.VideoFrameWriter;
+
+import java.awt.*;
 import java.awt.font.FontRenderContext;
 import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
@@ -29,17 +27,9 @@ import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.text.DateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.TreeMap;
-
-import sk.freemap.gpxAnimator.frameWriter.FileFrameWriter;
-import sk.freemap.gpxAnimator.frameWriter.FrameWriter;
-import sk.freemap.gpxAnimator.frameWriter.VideoFrameWriter;
 
 
 public class Renderer {
@@ -217,6 +207,8 @@ public class Renderer {
 
 		final boolean keepLastFrame = cfg.getKeepLastFrame() != null && cfg.getKeepLastFrame().longValue() > 0;
 
+		final Photos photos = new Photos(cfg.getPhotos());
+
 		float skip = -1f;
 		for (int frame = 1; frame < frames; frame++) {
 			if (rc.isCancelled1()) {
@@ -235,7 +227,8 @@ public class Renderer {
 				continue;
 			}
 
-			rc.setProgress1((int) (100.0 * frame / frames), "Rendering Frame: " + frame + "/" + (frames - 1));
+			final int pct = (int) (100.0 * frame / frames);
+			rc.setProgress1(pct, "Rendering Frame: " + frame + "/" + (frames - 1));
 
 			paint(bi, frame, 0);
 
@@ -261,6 +254,8 @@ public class Renderer {
 			}
 
 			frameWriter.addFrame(bi2);
+
+			photos.render(time, cfg, bi2, frameWriter, rc, pct);
 
 			if (keepLastFrame && frame == frames - 1) { // last frame
 				final long ms = cfg.getKeepLastFrame().longValue();

--- a/src/main/java/sk/freemap/gpxAnimator/ui/FileSelector.java
+++ b/src/main/java/sk/freemap/gpxAnimator/ui/FileSelector.java
@@ -14,21 +14,15 @@
  */
 package sk.freemap.gpxAnimator.ui;
 
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.util.prefs.Preferences;
-
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JFileChooser;
-import javax.swing.JPanel;
-import javax.swing.JTextField;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 
 public abstract class FileSelector extends JPanel {
 	private static final long serialVersionUID = 3157365691996396016L;
@@ -46,7 +40,7 @@ public abstract class FileSelector extends JPanel {
 	/**
 	 * Create the panel.
 	 */
-	public FileSelector() {
+	public FileSelector(final int fileSelectionMode) {
 		setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
 		
 		fileTextField = new JTextField();
@@ -88,6 +82,8 @@ public abstract class FileSelector extends JPanel {
 				if (fileChooser == null) {
 					fileChooser = new JFileChooser();
 				}
+
+				fileChooser.setFileSelectionMode(fileSelectionMode);
 				
 				final Preferences prefs = Preferences.userRoot().node("app");
 				final String lastCwd = prefs.get(MainFrame.PREF_LAST_CWD, null);

--- a/src/main/java/sk/freemap/gpxAnimator/ui/GeneralSettingsPanel.java
+++ b/src/main/java/sk/freemap/gpxAnimator/ui/GeneralSettingsPanel.java
@@ -1,5 +1,18 @@
 package sk.freemap.gpxAnimator.ui;
 
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+import sk.freemap.gpxAnimator.Configuration;
+import sk.freemap.gpxAnimator.Option;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -16,30 +29,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSlider;
-import javax.swing.JSpinner;
-import javax.swing.JTextArea;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.border.EmptyBorder;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-import javax.swing.filechooser.FileNameExtensionFilter;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
-
-import sk.freemap.gpxAnimator.Configuration;
-import sk.freemap.gpxAnimator.Option;
+import static javax.swing.JFileChooser.DIRECTORIES_ONLY;
+import static javax.swing.JFileChooser.FILES_ONLY;
 
 abstract class GeneralSettingsPanel extends JPanel {
 
@@ -64,6 +55,8 @@ abstract class GeneralSettingsPanel extends JPanel {
 	private final JSpinner keepLastFrameSpinner;
 	private final JSpinner totalTimeSpinner;
 	private JTextArea attributionTextArea;
+	private final FileSelector photosDirectorySelector;
+	private final JSpinner photoTimeSpinner;
 
 	private List<MapTemplate> mapTamplateList;
 
@@ -91,9 +84,9 @@ abstract class GeneralSettingsPanel extends JPanel {
 		setBorder(new EmptyBorder(5, 5, 5, 5));
 		final GridBagLayout gridBagLayout = new GridBagLayout();
 		gridBagLayout.columnWidths = new int[]{91, 100, 0, 0};
-		gridBagLayout.rowHeights = new int[]{14, 20, 20, 20, 14, 20, 20, 20, 20, 20, 20, 20, 20, 50, 45, 20, 21, 23, 20, 20, 0};
+		gridBagLayout.rowHeights = new int[]{14, 20, 20, 20, 14, 20, 20, 20, 20, 20, 20, 20, 20, 50, 45, 20, 21, 23, 20, 20, 20, 0};
 		gridBagLayout.columnWeights = new double[]{0.0, 1.0, 0.0, Double.MIN_VALUE};
-		gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE};
+		gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE};
 		setLayout(gridBagLayout);
 
 						final JLabel lblOutput = new JLabel("Output");
@@ -104,7 +97,7 @@ abstract class GeneralSettingsPanel extends JPanel {
 						gbc_lblOutput.gridy = 0;
 						add(lblOutput, gbc_lblOutput);
 
-				outputFileSelector = new FileSelector() {
+				outputFileSelector = new FileSelector(FILES_ONLY) {
 					private static final long serialVersionUID = 7372002778976603239L;
 
 					@Override
@@ -627,6 +620,52 @@ abstract class GeneralSettingsPanel extends JPanel {
 		gbc_keepLastFrameSpinner.gridy = 19;
 		add(keepLastFrameSpinner, gbc_keepLastFrameSpinner);
 		keepLastFrameSpinner.addChangeListener(changeListener);
+
+		final JLabel lblPhotosDirectorySelector = new JLabel("Photo Directory");
+		final GridBagConstraints gbc_lblPhotosDirectorySelector = new GridBagConstraints();
+		gbc_lblPhotosDirectorySelector.anchor = GridBagConstraints.EAST;
+		gbc_lblPhotosDirectorySelector.insets = new Insets(0, 0, 0, 5);
+		gbc_lblPhotosDirectorySelector.gridx = 0;
+		gbc_lblPhotosDirectorySelector.gridy = 20;
+		add(lblPhotosDirectorySelector, gbc_lblPhotosDirectorySelector);
+
+		photosDirectorySelector = new FileSelector(DIRECTORIES_ONLY) {
+			private static final long serialVersionUID = 7372002778976603240L;
+
+			@Override
+			protected Type configure(final JFileChooser outputFileChooser) {
+				return Type.OPEN;
+			}
+		};
+
+		photosDirectorySelector.setToolTipText(Option.PHOTOS.getHelp());
+		final GridBagConstraints gbc_photosDirectorySelector = new GridBagConstraints();
+		gbc_photosDirectorySelector.fill = GridBagConstraints.BOTH;
+		gbc_photosDirectorySelector.insets = new Insets(0, 0, 5, 0);
+		gbc_photosDirectorySelector.gridx = 1;
+		gbc_photosDirectorySelector.gridy = 20;
+		add(photosDirectorySelector, gbc_photosDirectorySelector);
+
+		photosDirectorySelector.addPropertyChangeListener("filename", propertyChangeListener);
+
+		final JLabel lblPhotoTime = new JLabel("Show photos for");
+		final GridBagConstraints gbc_lblPhotoTime = new GridBagConstraints();
+		gbc_lblPhotoTime.anchor = GridBagConstraints.EAST;
+		gbc_lblPhotoTime.insets = new Insets(0, 0, 0, 5);
+		gbc_lblPhotoTime.gridx = 0;
+		gbc_lblPhotoTime.gridy = 21;
+		add(lblPhotoTime, gbc_lblPhotoTime);
+
+		photoTimeSpinner = new JSpinner();
+		photoTimeSpinner.setToolTipText(Option.PHOTO_TIME.getHelp());
+		photoTimeSpinner.setModel(new DurationSpinnerModel());
+		photoTimeSpinner.setEditor(new DurationEditor(photoTimeSpinner));
+		final GridBagConstraints gbc_photoTimeSpinner = new GridBagConstraints();
+		gbc_photoTimeSpinner.fill = GridBagConstraints.HORIZONTAL;
+		gbc_photoTimeSpinner.gridx = 1;
+		gbc_photoTimeSpinner.gridy = 21;
+		add(photoTimeSpinner, gbc_photoTimeSpinner);
+		photoTimeSpinner.addChangeListener(changeListener);
 	}
 
 	private List<MapTemplate> readMaps() {
@@ -705,6 +744,7 @@ abstract class GeneralSettingsPanel extends JPanel {
 		fpsSpinner.setValue(c.getFps());
 		totalTimeSpinner.setValue(c.getTotalTime());
 		backgroundMapVisibilitySlider.setValue((int) (c.getBackgroundMapVisibility() * 100));
+		photoTimeSpinner.setValue(c.getPhotoTime());
 
 		final String tmsUrlTemplate = c.getTmsUrlTemplate();
 		found: {
@@ -755,7 +795,8 @@ abstract class GeneralSettingsPanel extends JPanel {
 		b.fontSize((Integer) fontSizeSpinner.getValue());
 		b.markerSize((Double) markerSizeSpinner.getValue());
 		b.waypointSize((Double) waypointSizeSpinner.getValue());
-
+		b.photos(new File(photosDirectorySelector.getFilename()));
+		b.photoTime((Long) photoTimeSpinner.getValue());
 		b.attribution(attributionTextArea.getText().replace("%MAP_ATTRIBUTION%",
 				tmsItem instanceof MapTemplate && ((MapTemplate) tmsItem).getAttributionText() != null
 				? ((MapTemplate) tmsItem).getAttributionText() : "").trim());

--- a/src/main/java/sk/freemap/gpxAnimator/ui/TrackSettingsPanel.java
+++ b/src/main/java/sk/freemap/gpxAnimator/ui/TrackSettingsPanel.java
@@ -1,5 +1,18 @@
 package sk.freemap.gpxAnimator.ui;
 
+import sk.freemap.gpxAnimator.Option;
+import sk.freemap.gpxAnimator.TrackConfiguration;
+import sk.freemap.gpxAnimator.TrackConfiguration.Builder;
+import sk.freemap.gpxAnimator.UserException;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -9,25 +22,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 
-import javax.swing.JButton;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JSpinner;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.border.EmptyBorder;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.filechooser.FileFilter;
-import javax.swing.filechooser.FileNameExtensionFilter;
-
-import sk.freemap.gpxAnimator.Option;
-import sk.freemap.gpxAnimator.TrackConfiguration;
-import sk.freemap.gpxAnimator.TrackConfiguration.Builder;
-import sk.freemap.gpxAnimator.UserException;
+import static javax.swing.JFileChooser.FILES_ONLY;
 
 abstract class TrackSettingsPanel extends JPanel {
 
@@ -63,7 +58,7 @@ abstract class TrackSettingsPanel extends JPanel {
 		gbc_lblGpx.gridy = 0;
 		add(lblGpx, gbc_lblGpx);
 		
-		inputGpxFileSelector = new FileSelector() {
+		inputGpxFileSelector = new FileSelector(FILES_ONLY) {
 			private static final long serialVersionUID = -7085193817022374995L;
 
 			@Override


### PR DESCRIPTION
This is a very first and easy implementation. The user can specify a directory containing the photos and the amount of time, a photo should be shown above the map. The photos can be JPEG or PNG encoded and must contain EXIF data with the date and time the photo was taken. This time is compared to the GPX time data to show the photo at the correct time/position on the map.

A demo video (Full HD with 60 fps) showing the result is available on YouTube: https://youtu.be/5b7kQv65dOE

Yes, there is plenty of room for improvements… :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zdila/gpx-animator/62)
<!-- Reviewable:end -->
