### PR TITLE
Implementation of map tile cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,5 +99,11 @@
 			<artifactId>imgscalr-lib</artifactId>
 			<version>4.2</version>
 		</dependency>
+			<dependency>
+			<artifactId>commons-io</artifactId>
+			<groupId>commons-io</groupId>
+			<scope>compile</scope>
+			<version>2.6</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 			<artifactId>imgscalr-lib</artifactId>
 			<version>4.2</version>
 		</dependency>
-			<dependency>
+		<dependency>
 			<artifactId>commons-io</artifactId>
 			<groupId>commons-io</groupId>
 			<scope>compile</scope>

--- a/src/main/java/sk/freemap/gpxAnimator/CommandLineConfigurationFactory.java
+++ b/src/main/java/sk/freemap/gpxAnimator/CommandLineConfigurationFactory.java
@@ -151,7 +151,7 @@ public final class CommandLineConfigurationFactory {
 					case TILE_CACHE_PATH:
 						cfg.tileCachePath(args[++i]);
 						break;
-					case TILE_CACHE_AGE_LIMIT:
+					case TILE_CACHE_TIME_LIMIT:
 						cfg.tileCacheTimeLimit(Long.parseLong(args[++i]));
 						break;
 					case TIME_OFFSET:

--- a/src/main/java/sk/freemap/gpxAnimator/CommandLineConfigurationFactory.java
+++ b/src/main/java/sk/freemap/gpxAnimator/CommandLineConfigurationFactory.java
@@ -148,6 +148,12 @@ public final class CommandLineConfigurationFactory {
 					case TAIL_DURATION:
 						cfg.tailDuration(Long.parseLong(args[++i]));
 						break;
+					case TILE_CACHE_PATH:
+						cfg.tileCachePath(args[++i]);
+						break;
+					case TILE_CACHE_AGE_LIMIT:
+						cfg.tileCacheTimeLimit(Long.parseLong(args[++i]));
+						break;
 					case TIME_OFFSET:
 						final String s2 = args[++i].trim();
 						timeOffsetList.add(s2.isEmpty() ? null : Long.valueOf(s2));

--- a/src/main/java/sk/freemap/gpxAnimator/Configuration.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Configuration.java
@@ -64,7 +64,7 @@ public class Configuration {
 	private Long photoTime;
 	
 	private String tileCachePath;
-	private Long tileCacheTimeLimit;
+	private Long tileCacheTimeLimit;    // Time limit is in seconds
 
 	@XmlElementWrapper
 	@XmlElement(name = "trackConfiguration")
@@ -86,7 +86,7 @@ public class Configuration {
 			final int fontSize, final Double markerSize, final Double waypointSize,
 			final Double minLon, final Double maxLon, final Double minLat, final Double maxLat,
 			final File photos, final Long photoTime,
-			final String cachePath, final Long cacheTimeLimit,
+			final String tileCachePath, final Long tileCacheTimeLimit,
 			final List<TrackConfiguration> trackConfigurationList) {
 		
 		this.margin = margin;
@@ -115,8 +115,8 @@ public class Configuration {
 		this.maxLat = maxLat;
 		this.photos = photos;
 		this.photoTime = photoTime;
-		this.tileCachePath = cachePath;
-		this.tileCacheTimeLimit = cacheTimeLimit;
+		this.tileCachePath = tileCachePath;
+		this.tileCacheTimeLimit = tileCacheTimeLimit;
 	}
 
 
@@ -300,7 +300,7 @@ public class Configuration {
 		private Long photoTime = 3_000L;
 		
 		private String tileCachePath;
-		private long tileCacheTimeLimit = 12L * 60L * 60L; // seconds
+		private long tileCacheTimeLimit = 12L * 60L * 60L; // Default is 12 hours
 
 		private final List<TrackConfiguration> trackConfigurationList = new ArrayList<TrackConfiguration>();
 		

--- a/src/main/java/sk/freemap/gpxAnimator/Configuration.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Configuration.java
@@ -62,6 +62,9 @@ public class Configuration {
 
 	private File photos;
 	private Long photoTime;
+	
+	private String tileCachePath;
+	private Long tileCacheTimeLimit;
 
 	@XmlElementWrapper
 	@XmlElement(name = "trackConfiguration")
@@ -83,6 +86,7 @@ public class Configuration {
 			final int fontSize, final Double markerSize, final Double waypointSize,
 			final Double minLon, final Double maxLon, final Double minLat, final Double maxLat,
 			final File photos, final Long photoTime,
+			final String cachePath, final Long cacheTimeLimit,
 			final List<TrackConfiguration> trackConfigurationList) {
 		
 		this.margin = margin;
@@ -111,6 +115,8 @@ public class Configuration {
 		this.maxLat = maxLat;
 		this.photos = photos;
 		this.photoTime = photoTime;
+		this.tileCachePath = cachePath;
+		this.tileCacheTimeLimit = cacheTimeLimit;
 	}
 
 
@@ -238,6 +244,16 @@ public class Configuration {
 	}
 
 
+    public String getTileCachePath() {
+        return tileCachePath;
+    }
+
+
+    public Long getTileCacheTimeLimit() {
+        return tileCacheTimeLimit;
+    }
+
+
 	public List<TrackConfiguration> getTrackConfigurationList() {
 		return trackConfigurationList;
 	}
@@ -282,6 +298,9 @@ public class Configuration {
 
 		private File photos;
 		private Long photoTime = 3_000L;
+		
+		private String tileCachePath;
+		private long tileCacheTimeLimit = 12L * 60L * 60L; // seconds
 
 		private final List<TrackConfiguration> trackConfigurationList = new ArrayList<TrackConfiguration>();
 		
@@ -296,6 +315,7 @@ public class Configuration {
 					fontSize, markerSize, waypointSize,
 					minLon,	maxLon,	minLat,	maxLat,
 					photos, photoTime,
+					tileCachePath, tileCacheTimeLimit,
 
 					Collections.unmodifiableList(trackConfigurationList)
 			);
@@ -427,6 +447,16 @@ public class Configuration {
 			return this;
 		}
 
+		public Builder tileCachePath(final String tileCachePath) {
+			this.tileCachePath = tileCachePath;
+			return this;
+		}
+
+		public Builder tileCacheTimeLimit(final Long tileCacheTimeLimit) {
+			this.tileCacheTimeLimit = tileCacheTimeLimit;
+			return this;
+		}
+
 		public Builder addTrackConfiguration(final TrackConfiguration trackConfiguration) {
 			this.trackConfigurationList.add(trackConfiguration);
 			return this;
@@ -454,6 +484,8 @@ public class Configuration {
 				+ ", waypointSize=" + waypointSize
 				+ ", photos=" + photos
 				+ ", photoTime=" + photoTime
+				+ ", tileCachePath=" + tileCachePath
+				+ ", tileCacheTimeLimit=" + tileCacheTimeLimit
 				+ ", trackConfigurationList=" + trackConfigurationList
 				+ "]";
 	}

--- a/src/main/java/sk/freemap/gpxAnimator/Help.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Help.java
@@ -55,7 +55,7 @@ public class Help {
 		w.writeOptionHelp(Option.SKIP_IDLE, null, false, cfg.isSkipIdle());
 		w.writeOptionHelp(Option.SPEEDUP, "speedup", false, cfg.getSpeedup());
 		w.writeOptionHelp(Option.TAIL_DURATION, "time", false, cfg.getTailDuration());
-		w.writeOptionHelp(Option.TILE_CACHE_AGE_LIMIT, "seconds", false, cfg.getTileCacheTimeLimit());
+		w.writeOptionHelp(Option.TILE_CACHE_TIME_LIMIT, "seconds", false, cfg.getTileCacheTimeLimit());
 		w.writeOptionHelp(Option.TILE_CACHE_PATH, "text", false, cfg.getTileCachePath());
 		w.writeOptionHelp(Option.TIME_OFFSET, "milliseconds", true, tc.getTimeOffset());
 		w.writeOptionHelp(Option.TMS_URL_TEMPLATE, "template", false, cfg.getTmsUrlTemplate());

--- a/src/main/java/sk/freemap/gpxAnimator/Help.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Help.java
@@ -55,6 +55,8 @@ public class Help {
 		w.writeOptionHelp(Option.SKIP_IDLE, null, false, cfg.isSkipIdle());
 		w.writeOptionHelp(Option.SPEEDUP, "speedup", false, cfg.getSpeedup());
 		w.writeOptionHelp(Option.TAIL_DURATION, "time", false, cfg.getTailDuration());
+		w.writeOptionHelp(Option.TILE_CACHE_AGE_LIMIT, "seconds", false, cfg.getTileCacheTimeLimit());
+		w.writeOptionHelp(Option.TILE_CACHE_PATH, "text", false, cfg.getTileCachePath());
 		w.writeOptionHelp(Option.TIME_OFFSET, "milliseconds", true, tc.getTimeOffset());
 		w.writeOptionHelp(Option.TMS_URL_TEMPLATE, "template", false, cfg.getTmsUrlTemplate());
 		w.writeOptionHelp(Option.TOTAL_TIME, "time", false, cfg.getTotalTime());

--- a/src/main/java/sk/freemap/gpxAnimator/Map.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Map.java
@@ -30,7 +30,9 @@ public class Map {
 
 	
 	public static void drawMap(final BufferedImage bi, final String tmsUrlTemplate, final float backgroundMapVisibility, final int zoom,
-			final double minX, final double maxX, final double minY, final double maxY, final RenderingContext rc) throws UserException {
+			final double minX, final double maxX, final double minY, final double maxY, final RenderingContext rc,
+			String tileCachePath, Long tileCacheTimeLimit) throws UserException {
+		
 		final Graphics2D ga = (Graphics2D) bi.getGraphics();
 
 		final double tileDblX = xToTileX(zoom, minX);
@@ -75,16 +77,7 @@ public class Map {
 				
 				rc.setProgress1((int) (100.0 * i / total), "Reading Map Tile: " + i + "/" + total);
 				
-				final BufferedImage tile;
-				System.setProperty("http.agent", "GPX Animator " + Constants.VERSION);
-				try {
-					tile = ImageIO.read(new URL(url));
-					if (tile == null) {
-						throw new UserException("could not read tile " + url);
-					}
-				} catch (final IOException e) {
-					throw new UserException("error reading tile " + url, e);
-				}
+				final BufferedImage tile = TileCache.getTile(url, tileCachePath, tileCacheTimeLimit);
 				
 				// convert to RGB format
 				final BufferedImage tile1 = new BufferedImage(tile.getWidth(), tile.getHeight(), BufferedImage.TYPE_INT_RGB);

--- a/src/main/java/sk/freemap/gpxAnimator/Option.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Option.java
@@ -39,7 +39,7 @@ public enum Option {
 	PHOTOS("photos", "a directory containing photos to be added to the animation (must contain EXIF information with date and time of photo taken)"),
 	PHOTO_TIME("photo-time", "the amount of time, a photo should be shown above the map"),
 	TILE_CACHE_PATH("tile-cache-path", "path to a directory to use for caching map tiles"),
-	TILE_CACHE_AGE_LIMIT("tile-cache-timeout", "time a cached map tile is valid"),
+	TILE_CACHE_TIME_LIMIT("tile-cache-timeout", "time a cached map tile is valid"),
 	HELP("help", "this help");
 	
 	private static java.util.Map<String, Option> map = new HashMap<String, Option>();

--- a/src/main/java/sk/freemap/gpxAnimator/Option.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Option.java
@@ -38,6 +38,8 @@ public enum Option {
 	SKIP_IDLE("skip-idle", "idle-skipping flashback effect duration in milliseconds; set to empty for no flashback"),
 	PHOTOS("photos", "a directory containing photos to be added to the animation (must contain EXIF information with date and time of photo taken)"),
 	PHOTO_TIME("photo-time", "the amount of time, a photo should be shown above the map"),
+	TILE_CACHE_PATH("tile-cache-path", "path to a directory to use for caching map tiles"),
+	TILE_CACHE_AGE_LIMIT("tile-cache-timeout", "number of hours a cached map tile is valid"),
 	HELP("help", "this help");
 	
 	private static java.util.Map<String, Option> map = new HashMap<String, Option>();

--- a/src/main/java/sk/freemap/gpxAnimator/Option.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Option.java
@@ -39,7 +39,7 @@ public enum Option {
 	PHOTOS("photos", "a directory containing photos to be added to the animation (must contain EXIF information with date and time of photo taken)"),
 	PHOTO_TIME("photo-time", "the amount of time, a photo should be shown above the map"),
 	TILE_CACHE_PATH("tile-cache-path", "path to a directory to use for caching map tiles"),
-	TILE_CACHE_AGE_LIMIT("tile-cache-timeout", "number of hours a cached map tile is valid"),
+	TILE_CACHE_AGE_LIMIT("tile-cache-timeout", "time a cached map tile is valid"),
 	HELP("help", "this help");
 	
 	private static java.util.Map<String, Option> map = new HashMap<String, Option>();

--- a/src/main/java/sk/freemap/gpxAnimator/Renderer.java
+++ b/src/main/java/sk/freemap/gpxAnimator/Renderer.java
@@ -201,7 +201,8 @@ public class Renderer {
 			ga.setColor(Color.white);
 			ga.fillRect(0, 0, realWidth, realHeight);
 		} else {
-			Map.drawMap(bi, cfg.getTmsUrlTemplate(), cfg.getBackgroundMapVisibility(), zoom, minX, maxX, minY, maxY, rc);
+			Map.drawMap(bi, cfg.getTmsUrlTemplate(), cfg.getBackgroundMapVisibility(), zoom, minX, maxX, minY, maxY, rc,
+						cfg.getTileCachePath(), cfg.getTileCacheTimeLimit());
 		}
 
 		if (cfg.getFontSize() > 0) {

--- a/src/main/java/sk/freemap/gpxAnimator/TileCache.java
+++ b/src/main/java/sk/freemap/gpxAnimator/TileCache.java
@@ -86,15 +86,17 @@ public class TileCache {
         String path = tileCachePath + File.separator + filename;
         File cacheFile = new File(path);
         
-        // Age out old file if needed
-        if (cacheFile.isFile()){
-            Date fileDate = new Date(cacheFile.lastModified());
+        // Age out all old files in cache directory.
+        // Our cache age is in seconds while the file times are in milliseconds
+        File cacheDir = new File(tileCachePath);
+        if (!cacheDir.exists())
+            cacheDir.mkdirs();
+
+        for (File cacheEntry : cacheDir.listFiles()) {
+            Date fileDate = new Date(cacheEntry.lastModified());
             long msBetweenDates = new Date().getTime() - fileDate.getTime();
             if ((msBetweenDates/1000) > tileCacheTimeLimit) {
-                if (!cacheFile.delete()) {
-                    // Treat as non-fatal after notifying user.
-                    System.out.println("Error: Failed to delete cache entry for " + url + " (" + path + ")");
-                } 
+                cacheEntry.delete();
             }
         }
         

--- a/src/main/java/sk/freemap/gpxAnimator/TileCache.java
+++ b/src/main/java/sk/freemap/gpxAnimator/TileCache.java
@@ -1,0 +1,135 @@
+/*
+ *  Copyright 2013 Martin Ždila, Freemap Slovakia
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+ 
+/*
+ *  Caching characteristics:
+ *  1. User specifies location of map tile image file cache.
+ *  2. If no cache specified, then no caching occurs.
+ *  3. Cache design assumes relatively few files (within OS limits of
+ *     number of files per directory).
+ *  4. Cache file names are based on a hash of the URL. This should remove
+ *     any naming issues because of special characters in the URL that might
+ *     be incompatible with the OS file naming restrictions. It also allows
+ *     for the cache to hold files for more than one TMS or for more than
+ *     one zoom level, etc.
+ *  5. Cache files age out based on a user specified age limit. By default
+ *     this is quite large (12 hours) because with the possible exception of
+ *     tiles from the default renderer at openstreetmap.org map tile generation
+ *     is not done very often (might be a month or two between changes).
+ */
+
+package sk.freemap.gpxAnimator;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import javax.imageio.ImageIO;
+import org.apache.commons.io.FileUtils;
+
+public class TileCache {
+
+    public static BufferedImage getTile( String url, String cachePath, Long cacheTimeLimit ) throws UserException {
+
+        if (cachePath == null) {
+            //System.out.println("No cache path defined, downloading " + url);
+            return unCachedGetTile( url );
+        }
+
+        //System.out.println("Caching enabled " + url);
+        return cachedGetTile( url, cachePath, cacheTimeLimit );
+    }
+
+    private static BufferedImage unCachedGetTile( String url ) throws UserException {
+        BufferedImage mapTile;
+        
+        System.setProperty("http.agent", "GPX Animator " + Constants.VERSION);
+        try {
+            mapTile = ImageIO.read(new URL(url));
+        } catch (final IOException e) {
+            throw new UserException("error reading tile " + url, e);
+        }
+        if (mapTile == null) {
+            throw new UserException("could not read tile " + url);
+        }
+        
+        return mapTile;
+    }
+    
+    private static BufferedImage cachedGetTile( String url, String cachePath, Long cacheTimeLimit ) throws UserException {
+        BufferedImage mapTile;
+        String fname = hashName(url);
+        String path = cachePath + File.separator + fname;
+        File f = new File(path);
+        
+        // Age out old file if needed
+        if (f.isFile()){
+            Date fileDate = new Date(f.lastModified());
+            long msBetweenDates = new Date().getTime() - fileDate.getTime();
+            if ((msBetweenDates/1000) > cacheTimeLimit) {
+                System.out.println("Removing cache entry for " + url); 
+                if (!f.delete()) {
+                    throw new UserException("failed to delete cache entry for " + url);
+                } 
+            }
+        }
+        
+        // If map tile is not in cache, then download it.
+        if (!f.isFile()) {
+            System.out.println("Cache miss for:" + path);
+            try {
+                FileUtils.copyURLToFile(new URL(url), f, 5000, 10000);
+            } catch (final IOException e) {
+                throw new UserException("error downloading tile " + url, e);
+            }
+        }
+        
+        // At this point a current map tile should be in our cache, so
+        // load it for the 
+        try {
+            mapTile = ImageIO.read(f);
+        } catch (final IOException e) {
+            throw new UserException("error reading tile " + url, e);
+        }
+        if (mapTile == null) {
+            throw new UserException("could not read tile " + url);
+        }
+        
+        return mapTile;
+    }
+    
+    private static String hashName(String url) throws UserException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return bytesToHex(digest.digest(url.getBytes(StandardCharsets.UTF_8)));
+        } catch (final NoSuchAlgorithmException e) {
+            throw new UserException("error creating hash name " + url, e);
+        }
+    }
+    
+    private static String bytesToHex(byte[] hash) {
+        StringBuffer hexString = new StringBuffer();
+        for (int i = 0; i < hash.length; i++) {
+        String hex = Integer.toHexString(0xff & hash[i]);
+        if(hex.length() == 1) hexString.append('0');
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+}

--- a/src/main/java/sk/freemap/gpxAnimator/ui/GeneralSettingsPanel.java
+++ b/src/main/java/sk/freemap/gpxAnimator/ui/GeneralSettingsPanel.java
@@ -91,52 +91,52 @@ abstract class GeneralSettingsPanel extends JPanel {
 		gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE};
 		setLayout(gridBagLayout);
 
-		final JLabel lblOutput = new JLabel("Output");
-		final GridBagConstraints gbc_lblOutput = new GridBagConstraints();
-		gbc_lblOutput.anchor = GridBagConstraints.EAST;
-		gbc_lblOutput.insets = new Insets(0, 0, 5, 5);
-		gbc_lblOutput.gridx = 0;
-		gbc_lblOutput.gridy = 0;
-		add(lblOutput, gbc_lblOutput);
+						final JLabel lblOutput = new JLabel("Output");
+						final GridBagConstraints gbc_lblOutput = new GridBagConstraints();
+						gbc_lblOutput.anchor = GridBagConstraints.EAST;
+						gbc_lblOutput.insets = new Insets(0, 0, 5, 5);
+						gbc_lblOutput.gridx = 0;
+						gbc_lblOutput.gridy = 0;
+						add(lblOutput, gbc_lblOutput);
 
-		outputFileSelector = new FileSelector(FILES_ONLY) {
-			private static final long serialVersionUID = 7372002778976603239L;
+				outputFileSelector = new FileSelector(FILES_ONLY) {
+					private static final long serialVersionUID = 7372002778976603239L;
 
-			@Override
-			protected Type configure(final JFileChooser outputFileChooser) {
-				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("JPEG Image Frames", "jpg"));
-				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("PNG Image Frames", "png"));
-				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("H.264 Encoded Video Files (*.mp4, *.mov, *.mkv)", "mp4", "mov", "mkv"));
-				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MPEG-1 Encoded Video Files (*.mpg)", "mpg"));
-				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MPEG-4 Encoded Video Files (*.avi)", "avi"));
-				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MS MPEG-4 Encoded Video Files (*.wmv, *.asf)", "wmv", "asf"));
-				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("Theora Encoded Video Files (*.ogv)", "ogv"));
-				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("FLV Encoded Video Files (*.flv)", "flv"));
-				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("RV10 Encoded Video Files (*.rm)", "rm"));
-				return Type.SAVE;
-			}
+					@Override
+					protected Type configure(final JFileChooser outputFileChooser) {
+						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("JPEG Image Frames", "jpg"));
+						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("PNG Image Frames", "png"));
+						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("H.264 Encoded Video Files (*.mp4, *.mov, *.mkv)", "mp4", "mov", "mkv"));
+						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MPEG-1 Encoded Video Files (*.mpg)", "mpg"));
+						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MPEG-4 Encoded Video Files (*.avi)", "avi"));
+						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MS MPEG-4 Encoded Video Files (*.wmv, *.asf)", "wmv", "asf"));
+						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("Theora Encoded Video Files (*.ogv)", "ogv"));
+						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("FLV Encoded Video Files (*.flv)", "flv"));
+						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("RV10 Encoded Video Files (*.rm)", "rm"));
+						return Type.SAVE;
+					}
 
-			@Override
-			protected String transformFilename(final String filename) {
-				if ((filename.toLowerCase().endsWith(".png") || filename.toLowerCase().endsWith(".jpg"))
-						&& String.format(filename, 100).equals(String.format(filename, 200))) {
-					final int n = filename.lastIndexOf('.');
-					return filename.substring(0, n) + "%08d" + filename.substring(n);
-				} else {
-					return filename;
-				}
-			}
-		};
+					@Override
+					protected String transformFilename(final String filename) {
+						if ((filename.toLowerCase().endsWith(".png") || filename.toLowerCase().endsWith(".jpg"))
+								&& String.format(filename, 100).equals(String.format(filename, 200))) {
+							final int n = filename.lastIndexOf('.');
+							return filename.substring(0, n) + "%08d" + filename.substring(n);
+						} else {
+							return filename;
+						}
+					}
+				};
 
-		outputFileSelector.setToolTipText(Option.OUTPUT.getHelp());
-		final GridBagConstraints gbc_outputFileSelector = new GridBagConstraints();
-		gbc_outputFileSelector.fill = GridBagConstraints.BOTH;
-		gbc_outputFileSelector.insets = new Insets(0, 0, 5, 0);
-		gbc_outputFileSelector.gridx = 1;
-		gbc_outputFileSelector.gridy = 0;
-		add(outputFileSelector, gbc_outputFileSelector);
+				outputFileSelector.setToolTipText(Option.OUTPUT.getHelp());
+				final GridBagConstraints gbc_outputFileSelector = new GridBagConstraints();
+				gbc_outputFileSelector.fill = GridBagConstraints.BOTH;
+				gbc_outputFileSelector.insets = new Insets(0, 0, 5, 0);
+				gbc_outputFileSelector.gridx = 1;
+				gbc_outputFileSelector.gridy = 0;
+				add(outputFileSelector, gbc_outputFileSelector);
 
-		outputFileSelector.addPropertyChangeListener("filename", propertyChangeListener);
+				outputFileSelector.addPropertyChangeListener("filename", propertyChangeListener);
 
 		final JLabel lblWidth = new JLabel("Width");
 		final GridBagConstraints gbc_lblWidth = new GridBagConstraints();
@@ -696,7 +696,7 @@ abstract class GeneralSettingsPanel extends JPanel {
 
 		tileCachePathSelector.addPropertyChangeListener("filename", propertyChangeListener);
 
-		final JLabel lblTileCacheTimeLimit = new JLabel("Tile cache age limit");
+		final JLabel lblTileCacheTimeLimit = new JLabel("Tile cache time limit");
 		final GridBagConstraints gbc_lblTileCacheTimeLimit = new GridBagConstraints();
 		gbc_lblTileCacheTimeLimit.anchor = GridBagConstraints.EAST;
 		gbc_lblTileCacheTimeLimit.insets = new Insets(0, 0, 0, 5);
@@ -705,7 +705,7 @@ abstract class GeneralSettingsPanel extends JPanel {
 		add(lblTileCacheTimeLimit, gbc_lblTileCacheTimeLimit);
 
 		tileCacheTimeLimitSpinner = new JSpinner();
-		tileCacheTimeLimitSpinner.setToolTipText(Option.TILE_CACHE_AGE_LIMIT.getHelp());
+		tileCacheTimeLimitSpinner.setToolTipText(Option.TILE_CACHE_TIME_LIMIT.getHelp());
 		tileCacheTimeLimitSpinner.setModel(new DurationSpinnerModel());
 		tileCacheTimeLimitSpinner.setEditor(new DurationEditor(tileCacheTimeLimitSpinner));
 		final GridBagConstraints gbc_tileCacheTimeLimitSpinner = new GridBagConstraints();
@@ -795,7 +795,7 @@ abstract class GeneralSettingsPanel extends JPanel {
 		totalTimeSpinner.setValue(c.getTotalTime());
 		backgroundMapVisibilitySlider.setValue((int) (c.getBackgroundMapVisibility() * 100));
 		photoTimeSpinner.setValue(c.getPhotoTime());
-		tileCacheTimeLimitSpinner.setValue(1000L*c.getTileCacheTimeLimit());
+		tileCacheTimeLimitSpinner.setValue(1000L*c.getTileCacheTimeLimit()); // Spinner is in ms, limit is in second
 		tileCachePathSelector.setFilename(c.getTileCachePath());
 
 		final String tmsUrlTemplate = c.getTmsUrlTemplate();

--- a/src/main/java/sk/freemap/gpxAnimator/ui/GeneralSettingsPanel.java
+++ b/src/main/java/sk/freemap/gpxAnimator/ui/GeneralSettingsPanel.java
@@ -57,6 +57,8 @@ abstract class GeneralSettingsPanel extends JPanel {
 	private JTextArea attributionTextArea;
 	private final FileSelector photosDirectorySelector;
 	private final JSpinner photoTimeSpinner;
+	private final FileSelector tileCachePathSelector;
+	private final JSpinner tileCacheTimeLimitSpinner;
 
 	private List<MapTemplate> mapTamplateList;
 
@@ -89,52 +91,52 @@ abstract class GeneralSettingsPanel extends JPanel {
 		gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, Double.MIN_VALUE};
 		setLayout(gridBagLayout);
 
-						final JLabel lblOutput = new JLabel("Output");
-						final GridBagConstraints gbc_lblOutput = new GridBagConstraints();
-						gbc_lblOutput.anchor = GridBagConstraints.EAST;
-						gbc_lblOutput.insets = new Insets(0, 0, 5, 5);
-						gbc_lblOutput.gridx = 0;
-						gbc_lblOutput.gridy = 0;
-						add(lblOutput, gbc_lblOutput);
+		final JLabel lblOutput = new JLabel("Output");
+		final GridBagConstraints gbc_lblOutput = new GridBagConstraints();
+		gbc_lblOutput.anchor = GridBagConstraints.EAST;
+		gbc_lblOutput.insets = new Insets(0, 0, 5, 5);
+		gbc_lblOutput.gridx = 0;
+		gbc_lblOutput.gridy = 0;
+		add(lblOutput, gbc_lblOutput);
 
-				outputFileSelector = new FileSelector(FILES_ONLY) {
-					private static final long serialVersionUID = 7372002778976603239L;
+		outputFileSelector = new FileSelector(FILES_ONLY) {
+			private static final long serialVersionUID = 7372002778976603239L;
 
-					@Override
-					protected Type configure(final JFileChooser outputFileChooser) {
-						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("JPEG Image Frames", "jpg"));
-						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("PNG Image Frames", "png"));
-						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("H.264 Encoded Video Files (*.mp4, *.mov, *.mkv)", "mp4", "mov", "mkv"));
-						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MPEG-1 Encoded Video Files (*.mpg)", "mpg"));
-						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MPEG-4 Encoded Video Files (*.avi)", "avi"));
-						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MS MPEG-4 Encoded Video Files (*.wmv, *.asf)", "wmv", "asf"));
-						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("Theora Encoded Video Files (*.ogv)", "ogv"));
-						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("FLV Encoded Video Files (*.flv)", "flv"));
-						outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("RV10 Encoded Video Files (*.rm)", "rm"));
-						return Type.SAVE;
-					}
+			@Override
+			protected Type configure(final JFileChooser outputFileChooser) {
+				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("JPEG Image Frames", "jpg"));
+				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("PNG Image Frames", "png"));
+				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("H.264 Encoded Video Files (*.mp4, *.mov, *.mkv)", "mp4", "mov", "mkv"));
+				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MPEG-1 Encoded Video Files (*.mpg)", "mpg"));
+				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MPEG-4 Encoded Video Files (*.avi)", "avi"));
+				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MS MPEG-4 Encoded Video Files (*.wmv, *.asf)", "wmv", "asf"));
+				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("Theora Encoded Video Files (*.ogv)", "ogv"));
+				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("FLV Encoded Video Files (*.flv)", "flv"));
+				outputFileChooser.addChoosableFileFilter(new FileNameExtensionFilter("RV10 Encoded Video Files (*.rm)", "rm"));
+				return Type.SAVE;
+			}
 
-					@Override
-					protected String transformFilename(final String filename) {
-						if ((filename.toLowerCase().endsWith(".png") || filename.toLowerCase().endsWith(".jpg"))
-								&& String.format(filename, 100).equals(String.format(filename, 200))) {
-							final int n = filename.lastIndexOf('.');
-							return filename.substring(0, n) + "%08d" + filename.substring(n);
-						} else {
-							return filename;
-						}
-					}
-				};
+			@Override
+			protected String transformFilename(final String filename) {
+				if ((filename.toLowerCase().endsWith(".png") || filename.toLowerCase().endsWith(".jpg"))
+						&& String.format(filename, 100).equals(String.format(filename, 200))) {
+					final int n = filename.lastIndexOf('.');
+					return filename.substring(0, n) + "%08d" + filename.substring(n);
+				} else {
+					return filename;
+				}
+			}
+		};
 
-				outputFileSelector.setToolTipText(Option.OUTPUT.getHelp());
-				final GridBagConstraints gbc_outputFileSelector = new GridBagConstraints();
-				gbc_outputFileSelector.fill = GridBagConstraints.BOTH;
-				gbc_outputFileSelector.insets = new Insets(0, 0, 5, 0);
-				gbc_outputFileSelector.gridx = 1;
-				gbc_outputFileSelector.gridy = 0;
-				add(outputFileSelector, gbc_outputFileSelector);
+		outputFileSelector.setToolTipText(Option.OUTPUT.getHelp());
+		final GridBagConstraints gbc_outputFileSelector = new GridBagConstraints();
+		gbc_outputFileSelector.fill = GridBagConstraints.BOTH;
+		gbc_outputFileSelector.insets = new Insets(0, 0, 5, 0);
+		gbc_outputFileSelector.gridx = 1;
+		gbc_outputFileSelector.gridy = 0;
+		add(outputFileSelector, gbc_outputFileSelector);
 
-				outputFileSelector.addPropertyChangeListener("filename", propertyChangeListener);
+		outputFileSelector.addPropertyChangeListener("filename", propertyChangeListener);
 
 		final JLabel lblWidth = new JLabel("Width");
 		final GridBagConstraints gbc_lblWidth = new GridBagConstraints();
@@ -666,6 +668,54 @@ abstract class GeneralSettingsPanel extends JPanel {
 		gbc_photoTimeSpinner.gridy = 21;
 		add(photoTimeSpinner, gbc_photoTimeSpinner);
 		photoTimeSpinner.addChangeListener(changeListener);
+
+		final JLabel lblTileCachePathSelector = new JLabel("Tile Cache Directory");
+		final GridBagConstraints gbc_lblTileCachePathSelector = new GridBagConstraints();
+		gbc_lblTileCachePathSelector.anchor = GridBagConstraints.EAST;
+		gbc_lblTileCachePathSelector.insets = new Insets(0, 0, 0, 5);
+		gbc_lblTileCachePathSelector.gridx = 0;
+		gbc_lblTileCachePathSelector.gridy = 22;
+		add(lblTileCachePathSelector, gbc_lblTileCachePathSelector);
+
+		tileCachePathSelector = new FileSelector(DIRECTORIES_ONLY) {
+			private static final long serialVersionUID = 7372002778979993241L;
+
+			@Override
+			protected Type configure(final JFileChooser outputFileChooser) {
+				return Type.OPEN;
+			}
+		};
+
+		tileCachePathSelector.setToolTipText(Option.TILE_CACHE_PATH.getHelp());
+		final GridBagConstraints gbc_tileCachePathSelector = new GridBagConstraints();
+		gbc_tileCachePathSelector.fill = GridBagConstraints.BOTH;
+		gbc_tileCachePathSelector.insets = new Insets(0, 0, 5, 0);
+		gbc_tileCachePathSelector.gridx = 1;
+		gbc_tileCachePathSelector.gridy = 22;
+		add(tileCachePathSelector, gbc_tileCachePathSelector);
+
+		tileCachePathSelector.addPropertyChangeListener("filename", propertyChangeListener);
+
+		final JLabel lblTileCacheTimeLimit = new JLabel("Tile cache age limit");
+		final GridBagConstraints gbc_lblTileCacheTimeLimit = new GridBagConstraints();
+		gbc_lblTileCacheTimeLimit.anchor = GridBagConstraints.EAST;
+		gbc_lblTileCacheTimeLimit.insets = new Insets(0, 0, 0, 5);
+		gbc_lblTileCacheTimeLimit.gridx = 0;
+		gbc_lblTileCacheTimeLimit.gridy = 23;
+		add(lblTileCacheTimeLimit, gbc_lblTileCacheTimeLimit);
+
+		tileCacheTimeLimitSpinner = new JSpinner();
+		tileCacheTimeLimitSpinner.setToolTipText(Option.TILE_CACHE_AGE_LIMIT.getHelp());
+		tileCacheTimeLimitSpinner.setModel(new DurationSpinnerModel());
+		tileCacheTimeLimitSpinner.setEditor(new DurationEditor(tileCacheTimeLimitSpinner));
+		final GridBagConstraints gbc_tileCacheTimeLimitSpinner = new GridBagConstraints();
+		gbc_tileCacheTimeLimitSpinner.fill = GridBagConstraints.HORIZONTAL;
+		gbc_tileCacheTimeLimitSpinner.gridx = 1;
+		gbc_tileCacheTimeLimitSpinner.gridy = 23;
+		add(tileCacheTimeLimitSpinner, gbc_tileCacheTimeLimitSpinner);
+		tileCacheTimeLimitSpinner.addChangeListener(changeListener);
+		
+
 	}
 
 	private List<MapTemplate> readMaps() {
@@ -745,6 +795,8 @@ abstract class GeneralSettingsPanel extends JPanel {
 		totalTimeSpinner.setValue(c.getTotalTime());
 		backgroundMapVisibilitySlider.setValue((int) (c.getBackgroundMapVisibility() * 100));
 		photoTimeSpinner.setValue(c.getPhotoTime());
+		tileCacheTimeLimitSpinner.setValue(1000L*c.getTileCacheTimeLimit());
+		tileCachePathSelector.setFilename(c.getTileCachePath());
 
 		final String tmsUrlTemplate = c.getTmsUrlTemplate();
 		found: {
@@ -797,6 +849,8 @@ abstract class GeneralSettingsPanel extends JPanel {
 		b.waypointSize((Double) waypointSizeSpinner.getValue());
 		b.photos(new File(photosDirectorySelector.getFilename()));
 		b.photoTime((Long) photoTimeSpinner.getValue());
+		b.tileCachePath(tileCachePathSelector.getFilename());
+		b.tileCacheTimeLimit((((Long) tileCacheTimeLimitSpinner.getValue())+500)/1000);
 		b.attribution(attributionTextArea.getText().replace("%MAP_ATTRIBUTION%",
 				tmsItem instanceof MapTemplate && ((MapTemplate) tmsItem).getAttributionText() != null
 				? ((MapTemplate) tmsItem).getAttributionText() : "").trim());


### PR DESCRIPTION
See: https://github.com/zdila/gpx-animator/issues/77

Implement a map tile cache to avoid downloading the same files each time
a slightly different rendering is tried. User specifies location of cache
and lifetime of cached tiles. If no cache is specified then revert to old
behavior of downloading tiles each time renderer is run.

This is a partial implementation because only the CLI has been updated to
allow specification of cache parameters. The GUI will need updating to
complete this enhancement.

Signed-off-by: Tod Fitch <tod@fitchfamily.org>