### PR TITLE
Add OpenTopoMap to known maps.

### DIFF
--- a/src/main/resources/maps.xml
+++ b/src/main/resources/maps.xml
@@ -128,6 +128,15 @@
         <attribution-url>https://openstreetmap.org/</attribution-url>
     </entry>
     <entry>
+        <name>OpenTopoMap</name>
+        <id>opentopomap</id>
+        <type>tms</type>
+        <url>https://{switch:a,b,c}.tile.opentopomap.org/{zoom}/{x}/{y}.png</url>
+        <max-zoom>17</max-zoom>
+        <attribution-text mandatory="true">Map data: OpenStreetMap contributors, SRTM | Map view: © OpenTopoMap (CC-BY-SA)</attribution-text>
+        <attribution-url>https://opentopomap.org/</attribution-url>
+    </entry>
+    <entry>
         <name>MapQuest OSM</name>
         <id>mapquest-osm</id>
         <type>tms</type>


### PR DESCRIPTION
Usage and licensing appears to be compatible, see: https://opentopomap.org/about

The English translation of pertinent text is:

> OpenTopoMap is licensed under CC-BY-SA. This means that the map may be used freely and free of charge, as long as the name is always mentioned and the transfer is possible under the same conditions.
> The tiles can be retrieved under the following path:
> https://{a|b|c}.tile.opentopomap.org/{z}/{x}/{y}.png
> 
> The following should be clearly visible as license text:
> Map data: OpenStreetMap contributors, SRTM | Map view: © OpenTopoMap (CC-BY-SA)

(Translated with www.DeepL.com/Translator)

Signed-off-by: Tod Fitch <tod@fitchfamily.org>