### PR TITLE
:bug: fix for bug #121 - wrong change listener registered to check box.

### DIFF
--- a/src/main/java/sk/freemap/gpxAnimator/ui/TrackSettingsPanel.java
+++ b/src/main/java/sk/freemap/gpxAnimator/ui/TrackSettingsPanel.java
@@ -25,6 +25,8 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -335,7 +337,12 @@ abstract class TrackSettingsPanel extends JPanel {
         forcedPointTimeIntervalSpinner.addChangeListener(changeListener);
         trimGpxStartSpinner.addChangeListener(changeListener);
         trimGpxEndSpinner.addChangeListener(changeListener);
-        enableIconCheckBox.addChangeListener(changeListener);
+        enableIconCheckBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(final ItemEvent e) {
+                configurationChanged();
+            }
+        });
     }
 
 


### PR DESCRIPTION
 I couldn't reproduce at first using `jdk1.8.0_212` on OSX, I then built using `openjdk 11.0.4 2019-07-16` and ran under `OpenJDK Runtime Environment (build 11.0.4+11-post-Ubuntu-1ubuntu219.04)` and saw the error immediately.