### PR TITLE
Smoothes map movement

### DIFF
--- a/src/main/java/app/gpx_animator/CommandLineConfigurationFactory.java
+++ b/src/main/java/app/gpx_animator/CommandLineConfigurationFactory.java
@@ -151,6 +151,7 @@ public final class CommandLineConfigurationFactory {
                         }
                         case VIEWPORT_WIDTH -> cfg.viewportWidth(Integer.parseInt(args[++i]));
                         case VIEWPORT_HEIGHT -> cfg.viewportHeight(Integer.parseInt(args[++i]));
+                        case VIEWPORT_INERTIA -> cfg.viewportInertia(Integer.parseInt(args[++i]));
                         case WAYPOINT_SIZE -> cfg.waypointSize(Double.parseDouble(args[++i]));
                         case WIDTH -> cfg.width(Integer.parseInt(args[++i]));
                         case ZOOM -> cfg.zoom(Integer.parseInt(args[++i]));

--- a/src/main/java/app/gpx_animator/Configuration.java
+++ b/src/main/java/app/gpx_animator/Configuration.java
@@ -37,6 +37,7 @@ public final class Configuration {
     private static final Color DEFAULT_PREDRAW_TRACK_COLOR = Color.lightGray;
     private static final String DEFAULT_TMS_URL_TEMPLATE = "http://tile.openstreetmap.org/{zoom}/{x}/{y}.png";
     private static final int DEFAULT_MARGIN = 20;
+    private static final int DEFAULT_VIEWPORT_INERTIA = 50;
     public static final long DEFAULT_PHOTO_ANIMATION_DURATION = 700L;
 
     private int margin;
@@ -46,6 +47,7 @@ public final class Configuration {
 
     private Integer viewportWidth;
     private Integer viewportHeight;
+    private Integer viewportInertia = DEFAULT_VIEWPORT_INERTIA;
 
     private boolean preDrawTrack;
     private Color preDrawTrackColor;
@@ -113,7 +115,7 @@ public final class Configuration {
     @SuppressWarnings("checkstyle:ParameterNumber")
     private Configuration(
             final int margin, final Integer width, final Integer height, final Integer zoom,
-            final Integer viewportWidth, final Integer viewportHeight,
+            final Integer viewportWidth, final Integer viewportHeight, final Integer viewportInertia,
             final Double speedup, final long tailDuration, final Color tailColor, final double fps, final Long totalTime,
             final float backgroundMapVisibility, final String tmsUrlTemplate, final boolean skipIdle,
             final Color backgroundColor, final Color flashbackColor, final Long flashbackDuration,
@@ -132,6 +134,7 @@ public final class Configuration {
         this.zoom = zoom;
         this.viewportWidth = viewportWidth;
         this.viewportHeight = viewportHeight;
+        this.viewportInertia = viewportInertia;
         this.speedup = speedup;
         this.tailDuration = tailDuration;
         this.tailColor = tailColor;
@@ -190,6 +193,10 @@ public final class Configuration {
 
     public Integer getViewPortHeight() {
         return viewportHeight;
+    }
+
+    public Integer getViewPortInertia() {
+        return viewportInertia;
     }
 
     public Integer getZoom() {
@@ -341,6 +348,7 @@ public final class Configuration {
                 + ", zoom=" + zoom
                 + ", viewportWidth=" + viewportWidth
                 + ", viewportHeight=" + viewportHeight
+                + ", viewportInertia=" + viewportInertia
                 + ", speedup=" + speedup
                 + ", tailDuration=" + tailDuration
                 + ", tailColor=" + tailColor
@@ -386,6 +394,7 @@ public final class Configuration {
         private Integer zoom;
         private Integer viewportHeight;
         private Integer viewportWidth;
+        private Integer viewportInertia = DEFAULT_VIEWPORT_INERTIA;
         private Double speedup = 1000.0;
         private long tailDuration = 3600000;
         private Color tailColor = Color.BLACK;
@@ -424,7 +433,7 @@ public final class Configuration {
         public Configuration build() {
             return new Configuration(
                     margin, width, height, zoom,
-                    viewportWidth, viewportHeight,
+                    viewportWidth, viewportHeight, viewportInertia,
                     speedup, tailDuration, tailColor, fps, totalTime,
                     backgroundMapVisibility, tmsUrlTemplate,
                     skipIdle, backgroundColor, flashbackColor, flashbackDuration,
@@ -462,6 +471,11 @@ public final class Configuration {
 
         public Builder viewportWidth(final Integer viewportWidth) {
             this.viewportWidth = viewportWidth;
+            return this;
+        }
+
+        public Builder viewportInertia(final Integer viewportInertia) {
+            this.viewportInertia = viewportInertia;
             return this;
         }
 

--- a/src/main/java/app/gpx_animator/Help.java
+++ b/src/main/java/app/gpx_animator/Help.java
@@ -74,6 +74,7 @@ public final class Help {
         w.writeOptionHelp(Option.SPEED_UNIT, "SPEED", false, cfg.getSpeedUnit()); //NON-NLS
         w.writeOptionHelp(Option.VIEWPORT_WIDTH, "viewport-width", false, cfg.getViewPortWidth()); //NON-NLS
         w.writeOptionHelp(Option.VIEWPORT_HEIGHT, "viewport-height", false, cfg.getViewPortHeight()); //NON-NLS
+        w.writeOptionHelp(Option.VIEWPORT_INERTIA, "viewport-inertia", false, cfg.getViewPortInertia()); //NON-NLS
         w.writeOptionHelp(Option.WAYPOINT_SIZE, "size", false, cfg.getWaypointSize()); //NON-NLS
         w.writeOptionHelp(Option.WIDTH, "width", false, "(800)"); // TODO cfg.getWidth() NON-NLS
         w.writeOptionHelp(Option.ZOOM, "zoom", false, cfg.getZoom()); //NON-NLS

--- a/src/main/java/app/gpx_animator/Option.java
+++ b/src/main/java/app/gpx_animator/Option.java
@@ -34,6 +34,7 @@ public enum Option {
     ZOOM("zoom"),
     VIEWPORT_WIDTH("viewport-width"),
     VIEWPORT_HEIGHT("viewport-height"),
+    VIEWPORT_INERTIA("viewport-inertia"),
     FONT("font"),
     TMS_URL_TEMPLATE("tms-url-template"),
     ATTRIBUTION("attribution"),

--- a/src/main/java/app/gpx_animator/Renderer.java
+++ b/src/main/java/app/gpx_animator/Renderer.java
@@ -261,10 +261,17 @@ public final class Renderer {
             return bi;
         }
 
-        // track most recent markers while updating the running average x and y coords
-        this.recentMarkers.add(marker);
-        recentMarkersXSum += (double) marker.getX();
-        recentMarkersYSum += (double) marker.getY();
+        // Add most recent markers to a queue (while updating a running average
+        // of x and y coordinates). Note that this loop almost always adds just
+        // 1 element to the end of the queue, except on the first invocation, in
+        // which case it fills up the entire queue with just the first marker.
+        // This prevents jitter in the beginning of the movie
+        while (this.recentMarkers.size() < (cfg.getViewPortInertia() + 1)) {
+            this.recentMarkers.add(marker);
+            recentMarkersXSum += (double) marker.getX();
+            recentMarkersYSum += (double) marker.getY();
+        }
+
         while (this.recentMarkers.size() > cfg.getViewPortInertia()) {
             final Point2D m = this.recentMarkers.removeFirst();
             recentMarkersXSum -= (double) m.getX();

--- a/src/main/resources/i18n/Messages.properties
+++ b/src/main/resources/i18n/Messages.properties
@@ -61,6 +61,7 @@ option.help.trim-gpx-end=trim the end of the GPX file in milliseconds
 option.help.trim-gpx-start=trim the start of the GPX file in milliseconds
 option.help.viewport-height=video viewport height in pixels; if not specified equals height
 option.help.viewport-width=video viewport width in pixels; if not specified equals width
+option.help.viewport-inertia=video viewport inertia as number of most recent locations used to compute viewport location
 option.help.waypoint-size=waypoint size in pixels; for no waypoints specify 0
 option.help.width=video width in pixels; if not specified but zoom is specified, then computed from GPX bounding box and margin, otherwise 800
 option.help.zoom=map zoom typically from 1 to 18; if not specified and TMS URL Template (Background Map) is specified then it is computed from width


### PR DESCRIPTION
Smoothes out the moving map by averaging the most recent (x,y)
coordinates. The number of recent locations is controlled by
--viewport-inertia; the higher the number, the more sluggish the
viewport follows the dot.