### PR TITLE
Revert ":white_check_mark: Running integration test before each push"

### DIFF
--- a/config/git/pre-push
+++ b/config/git/pre-push
@@ -7,7 +7,7 @@
 git stash -q --keep-index
 
 # run the checks and tests with the gradle wrapper
-./gradlew check test integration
+./gradlew check test
 
 # store the last exit code in a variable
 RESULT=$?


### PR DESCRIPTION
This reverts commit 5acc93615749ef81fe91bc89c850a3d6dac91a2d.

Failing on missing i18n encourages developers to come up with bogus or
bad translations. Consider making this a warning rather than a critical
fail.