### PR TITLE
Add a --tms-user-agent option

### DIFF
--- a/src/main/java/app/gpx_animator/core/Help.java
+++ b/src/main/java/app/gpx_animator/core/Help.java
@@ -87,6 +87,7 @@ public final class Help {
         w.writeOptionHelp(Option.TAIL_COLOR_FADEOUT, "tail-color-fadeout", false, true); //NON-NLS
         w.writeOptionHelp(Option.TIME_OFFSET, "milliseconds", true, tc.getTimeOffset()); //NON-NLS
         w.writeOptionHelp(Option.TMS_URL_TEMPLATE, "tms-url-template", false, cfg.getTmsUrlTemplate()); //NON-NLS
+        w.writeOptionHelp(Option.TMS_USER_AGENT, "tms-user-agent", false, cfg.getTmsUserAgent()); //NON-NLS
         w.writeOptionHelp(Option.TOTAL_TIME, "time", false, cfg.getTotalTime()); //NON-NLS
         w.writeOptionHelp(Option.SPEED_UNIT, "speed", false, cfg.getSpeedUnit()); //NON-NLS
         w.writeOptionHelp(Option.VIEWPORT_WIDTH, "viewport-width", false, cfg.getViewportWidth()); //NON-NLS

--- a/src/main/java/app/gpx_animator/core/Option.java
+++ b/src/main/java/app/gpx_animator/core/Option.java
@@ -54,6 +54,7 @@ public enum Option {
     FONT("font"),
     WAYPOINT_FONT("waypoint-font"),
     TMS_URL_TEMPLATE("tms-url-template"),
+    TMS_USER_AGENT("tms-user-agent"),
     ATTRIBUTION("attribution"),
     BACKGROUND_MAP_VISIBILITY("background-map-visibility"),
     TOTAL_TIME("total-time"),

--- a/src/main/java/app/gpx_animator/core/configuration/Configuration.java
+++ b/src/main/java/app/gpx_animator/core/configuration/Configuration.java
@@ -73,6 +73,7 @@ public final class Configuration {
 
     private float backgroundMapVisibility;
     private String tmsUrlTemplate;
+    private String tmsUserAgent;
 
     private boolean skipIdle;
 
@@ -142,7 +143,7 @@ public final class Configuration {
             final int margin, final Integer width, final Integer height, final Integer zoom,
             final Integer viewportWidth, final Integer viewportHeight, final Integer viewportInertia,
             final Double speedup, final long tailDuration, final Color tailColor, final boolean tailColorFadeout, final double fps,
-            final Long totalTime, final float backgroundMapVisibility, final String tmsUrlTemplate, final boolean skipIdle,
+            final Long totalTime, final float backgroundMapVisibility, final String tmsUrlTemplate, final String tmsUserAgent, final boolean skipIdle,
             final Color backgroundColor, final File backgroundImage, final Color flashbackColor, final Long flashbackDuration,
             final boolean preDrawTrack, final Long keepFirstFrame, final Long keepLastFrame, final File output, final String attribution,
             final SpeedUnit speedUnit, final Font font, final Double markerSize, final Font waypointFont, final Double waypointSize,
@@ -170,6 +171,7 @@ public final class Configuration {
         this.totalTime = totalTime;
         this.backgroundMapVisibility = backgroundMapVisibility;
         this.tmsUrlTemplate = tmsUrlTemplate;
+        this.tmsUserAgent = tmsUserAgent;
         this.skipIdle = skipIdle;
         this.preDrawTrack = preDrawTrack;
         this.backgroundColor = backgroundColor;
@@ -271,6 +273,10 @@ public final class Configuration {
 
     public String getTmsUrlTemplate() {
         return tmsUrlTemplate;
+    }
+
+    public String getTmsUserAgent() {
+        return tmsUserAgent;
     }
 
     public boolean isSkipIdle() {
@@ -444,6 +450,7 @@ public final class Configuration {
         private Long totalTime;
         private float backgroundMapVisibility = 0.5f;
         private String tmsUrlTemplate = "";
+        private String tmsUserAgent = "";
         private boolean skipIdle = true;
         private boolean preDrawTrack = false;
         private Color backgroundColor = DEFAULT_BACKGROUND_COLOR;
@@ -483,7 +490,7 @@ public final class Configuration {
                     margin, width, height, zoom,
                     viewportWidth, viewportHeight, viewportInertia,
                     speedup, tailDuration, tailColor, tailColorFadeout, fps, totalTime,
-                    backgroundMapVisibility, tmsUrlTemplate,
+                    backgroundMapVisibility, tmsUrlTemplate, tmsUserAgent,
                     skipIdle, backgroundColor, backgroundImage, flashbackColor, flashbackDuration,
                     preDrawTrack, keepFirstFrame, keepLastFrame, output, attribution, speedUnit,
                     font, markerSize, waypointFont, waypointSize,
@@ -571,6 +578,11 @@ public final class Configuration {
 
         public Builder tmsUrlTemplate(final String tmsUrlTemplate) {
             this.tmsUrlTemplate = tmsUrlTemplate;
+            return this;
+        }
+
+        public Builder tmsUserAgent(final String tmsUserAgent) {
+            this.tmsUserAgent = tmsUserAgent;
             return this;
         }
 

--- a/src/main/java/app/gpx_animator/core/renderer/cache/TileCache.java
+++ b/src/main/java/app/gpx_animator/core/renderer/cache/TileCache.java
@@ -98,7 +98,7 @@ public final class TileCache {
     private static BufferedImage unCachedGetTile(final String url, final String userAgent) throws UserException {
         BufferedImage mapTile;
 
-        if (userAgent != null) {
+        if (!userAgent.isBlank()) {
             System.setProperty("http.agent", userAgent);
         } else {
             System.setProperty("http.agent", String.format("%s %s on %s %s (%s)", //NON-NLS

--- a/src/main/java/app/gpx_animator/core/renderer/plugins/BackgroundMapPlugin.java
+++ b/src/main/java/app/gpx_animator/core/renderer/plugins/BackgroundMapPlugin.java
@@ -41,6 +41,7 @@ public final class BackgroundMapPlugin implements RendererPlugin {
     private final transient ResourceBundle resourceBundle = Preferences.getResourceBundle();
 
     private final transient String tmsUrlTemplate;
+    private final transient String tmsUserAgent;
     private final transient float backgroundMapVisibility;
 
     private transient Integer zoom;
@@ -53,6 +54,7 @@ public final class BackgroundMapPlugin implements RendererPlugin {
 
     public BackgroundMapPlugin(@NonNull final Configuration configuration) {
         tmsUrlTemplate = configuration.getTmsUrlTemplate();
+        tmsUserAgent = configuration.getTmsUserAgent();
         backgroundMapVisibility = configuration.getBackgroundMapVisibility();
     }
 
@@ -130,7 +132,7 @@ public final class BackgroundMapPlugin implements RendererPlugin {
 
                 context.setProgress1((int) (100.0 * i / total), String.format(resourceBundle.getString("map.loadingtiles.progress"), i, total));
 
-                final var tile = TileCache.getTile(url, tileCacheDir, tileCacheTimeLimit);
+                final var tile = TileCache.getTile(url, tmsUserAgent, tileCacheDir, tileCacheTimeLimit);
 
                 // convert to RGB format
                 final var tile1 = new BufferedImage(tile.getWidth(), tile.getHeight(), BufferedImage.TYPE_INT_RGB);

--- a/src/main/java/app/gpx_animator/ui/cli/CommandLineConfigurationFactory.java
+++ b/src/main/java/app/gpx_animator/ui/cli/CommandLineConfigurationFactory.java
@@ -177,6 +177,7 @@ public final class CommandLineConfigurationFactory {
                             timeOffsetList.add(s2.isEmpty() ? null : Long.valueOf(s2)); // NOPMD -- null = not set
                         }
                         case TMS_URL_TEMPLATE -> cfg.tmsUrlTemplate(args[++i]);
+                        case TMS_USER_AGENT -> cfg.tmsUserAgent(args[++i]);
                         case TOTAL_TIME -> {
                             final var s3 = args[++i].trim();
                             cfg.totalTime(s3.isEmpty() ? null : Long.valueOf(s3)); // NOPMD -- null = not set

--- a/src/main/resources/i18n/Messages.properties
+++ b/src/main/resources/i18n/Messages.properties
@@ -68,6 +68,7 @@ option.help.tail-color-fadeout=fade out highlighted tail color at the end of the
 option.help.tail-duration=highlighted tail length in real time milliseconds
 option.help.time-offset=time offset for track in milliseconds
 option.help.tms-url-template=slippymap (TMS) URL template for background map where {x}, {y} and {zoom} placeholders will be replaced; for example use https://tile.openstreetmap.org/{zoom}/{x}/{y}.png for OpenStreetMap
+option.help.tms-user-agent=optional User Agent to use for requests to the TMS server
 option.help.total-time=total length of video in milliseconds; complementary to speedup
 option.help.track-icon-file=allows you to set an icon file for a track
 option.help.track-icon-mirror=mirror the track icon horizontally

--- a/src/main/resources/i18n/Messages_de.properties
+++ b/src/main/resources/i18n/Messages_de.properties
@@ -68,6 +68,7 @@ option.help.tail-color-fadeout=farbliche Hervorhebung der Streckenlinie am Ende 
 option.help.tail-duration=Dauer der farblichen Hervorhebung der Streckenlinie in Millisekunden
 option.help.time-offset=Zeitkorrektur der GPX-Track
 option.help.tms-url-template=slippymap (TMS) URL Vorlage für die Hintergrundkarte, wobei die Platzhalter {x}, {y} und {zoom} automatisch ersetzt werden; beispielsweise https://tile.openstreetmap.org/{zoom}/{x}/{y}.png für OpenStreetMap
+option.help.tms-user-agent=optionaler User Agent für Anfragen an den TMS-Server
 option.help.total-time=Gesamtzeit des Videos in Millisekunden; komplementär zur Beschleunigung der Echtzeit
 option.help.track-icon-file=Mit dieser Option können Sie eine Symboldatei für einen Track festlegen
 option.help.track-icon-mirror=Spiegelt das Symbol horizontal, um eine andere allgemeine Richtung anzuzeigen


### PR DESCRIPTION
This option lets the user customize the User Agent
that gpx animator uses when making requests to a TMS server.

Some TMS servers enforce rules on which user agents can be used.

I'm not sure if you're interested in this feature, but I needed it for my own usage.

The german help message comes from Google Translate, so not sure how good it is.